### PR TITLE
Add Azure Functions market monitoring timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 
 # Txt files
 *.txt
+!infra/monitoring/requirements.txt
 
 # PDF files
 *.pdf

--- a/infra/monitoring/.funcignore
+++ b/infra/monitoring/.funcignore
@@ -1,0 +1,12 @@
+# Azure Functions specific ignores
+local.settings.json
+*.pyc
+__pycache__/
+.env
+.venv/
+bin/
+obj/
+.git/
+.gitignore
+.vscode/
+python_packages/

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,156 @@
+# Market Monitoring Azure Function
+
+This Function App polls the Financial Datasets API every five minutes during U.S. equity market hours (9:30am–4:00pm ET). It
+evaluates simple price/volume heuristics for the configured watchlist and enqueues downstream analysis jobs only when fresh
+signals are detected. Cooldown metadata is stored in Cosmos DB so that identical alerts are not produced repeatedly.
+
+## Project Layout
+
+```
+infra/monitoring/
+├── .funcignore
+├── host.json
+├── local.settings.json.sample        # Copy to local.settings.json for local development
+├── market_monitor/
+│   ├── __init__.py                   # Timer trigger implementation
+│   └── function.json                 # Cron schedule (every 5 minutes)
+└── requirements.txt
+```
+
+The Function imports the existing `src.tools.api.get_prices` helper so that the same Financial Datasets client is reused in the
+serverless workload.
+
+## Environment Variables
+
+Set the following application settings (locally in `local.settings.json` or in the Function App configuration):
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `AzureWebJobsStorage` | ✅ | General-purpose storage account used by Azure Functions host. The queue connection string falls back to this value if a dedicated one is not provided. |
+| `FUNCTIONS_WORKER_RUNTIME` | ✅ | Must be set to `python` when running locally or on Azure. |
+| `FINANCIAL_DATASETS_API_KEY` | ✅ (for non-free tickers) | API key forwarded to `src/tools/api.py` when fetching price data. |
+| `MARKET_MONITOR_WATCHLIST` | ➖ | Comma-separated tickers to inspect (defaults to `AAPL,MSFT,NVDA`). |
+| `MARKET_MONITOR_PERCENT_CHANGE_THRESHOLD` | ➖ | Minimum intraday percentage change (e.g. `0.02` for 2%) required to trigger a signal. |
+| `MARKET_MONITOR_VOLUME_SPIKE_MULTIPLIER` | ➖ | Multiplier applied to the trailing average volume when flagging unusual activity (default `1.5`). |
+| `MARKET_MONITOR_VOLUME_LOOKBACK` | ➖ | Number of prior sessions used for the average volume baseline (default `10`). |
+| `MARKET_MONITOR_ANALYSIS_WINDOW_MINUTES` | ➖ | Width of the window sent to the queue worker for deeper analysis (default `120`). |
+| `MARKET_MONITOR_COOLDOWN_SECONDS` | ➖ | Minimum time between alerts for the same ticker (default `1800`, i.e. 30 minutes). |
+| `MARKET_MONITOR_LOOKBACK_DAYS` | ➖ | Amount of history retrieved per execution to compute the heuristics (default `30`). |
+| `MARKET_MONITOR_QUEUE_CONNECTION_STRING` | ✅ | Connection string for the storage account hosting the downstream queue (falls back to `AzureWebJobsStorage`). |
+| `MARKET_MONITOR_QUEUE_NAME` | ✅ | Target queue name consumed by `queue_worker.py`. |
+| `COSMOS_ENDPOINT` | ✅ | Cosmos DB account endpoint (e.g. `https://<account>.documents.azure.com:443/`). |
+| `COSMOS_KEY` | ✅ | Primary or secondary key for the Cosmos DB account. |
+| `COSMOS_DATABASE` | ✅ | Database used to persist ticker cooldown metadata. |
+| `COSMOS_CONTAINER` | ✅ | Container (partitioned by `/ticker`) storing the last-trigger timestamps. |
+
+> **Holiday Handling**: The timer trigger executes on every weekday regardless of market holidays. If holiday awareness is
+> required, add logic to reference an exchange calendar or pause the Function App via schedules.
+
+## Queue Payload Contract
+
+Messages pushed to the storage queue follow this schema:
+
+```json
+{
+  "tickers": ["AAPL"],
+  "analysis_window": {
+    "start": "2024-01-02T14:30:00+00:00",
+    "end": "2024-01-02T16:30:00+00:00"
+  },
+  "correlation_hints": {
+    "related_watchlist": ["MSFT", "NVDA"],
+    "basis": ["price_breakout", "volume_spike"]
+  },
+  "signals": ["price_breakout", "volume_spike"],
+  "market_snapshot": {
+    "percent_change": 0.0234,
+    "volume_ratio": 1.78,
+    "latest_close": 198.34,
+    "previous_close": 194.85,
+    "latest_volume": 54200123,
+    "average_volume": 30451200.0
+  },
+  "triggered_at": "2024-01-02T16:35:00+00:00"
+}
+```
+
+`queue_worker.py` can rely on `tickers`, `analysis_window`, and `correlation_hints` to hydrate deeper pipelines. Additional
+fields (`signals`, `market_snapshot`, `triggered_at`) provide diagnostic context.
+
+## Local Development
+
+1. Install Azure Functions Core Tools (v4) and the Python dependencies:
+   ```bash
+   npm i -g azure-functions-core-tools@4 --unsafe-perm true
+   cd infra/monitoring
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Copy the sample settings file and provide the required secrets:
+   ```bash
+   cp local.settings.json.sample local.settings.json
+   ```
+3. Start the Functions host (it will automatically respect the 5-minute cron schedule):
+   ```bash
+   func start
+   ```
+
+> For deterministic testing, you can invoke the timer manually: `func start --javascript` isn't necessary—use
+> `func start` and press **Ctrl+C** when finished. Alternatively, call the Python entrypoint with
+> `func host start --no-build` or trigger the function via `func run market_monitor`.
+
+## Deployment
+
+### Azure Functions Core Tools
+
+1. Create or reuse the required Azure resources:
+   - Storage account with the target queue.
+   - Cosmos DB account + database + container (`/ticker` partition key).
+   - Function App configured for Python 3.11 (Consumption or Premium plan).
+2. Publish the Function App:
+   ```bash
+   cd infra/monitoring
+   func azure functionapp publish <FUNCTION_APP_NAME>
+   ```
+3. Configure application settings (environment variables listed above) either through the Azure Portal, `az functionapp
+   config appsettings set`, or infrastructure-as-code. Ensure the queue and Cosmos DB credentials are present before enabling
+the Function.
+
+### GitHub Actions
+
+1. Store the secrets in the repository or organization (`AZURE_FUNCTIONAPP_NAME`, `AZURE_FUNCTIONAPP_PUBLISH_PROFILE`, queue and
+   Cosmos settings, API keys, etc.).
+2. Add a workflow similar to the snippet below:
+
+   ```yaml
+   name: Deploy Monitoring Function
+   on:
+     push:
+       branches: [ main ]
+       paths:
+         - 'infra/monitoring/**'
+   jobs:
+     build-and-deploy:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-python@v5
+           with:
+             python-version: '3.11'
+         - name: Install dependencies
+           run: |
+             cd infra/monitoring
+             pip install -r requirements.txt
+         - name: Azure Functions deploy
+           uses: Azure/functions-action@v1
+           with:
+             app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
+             publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+             package: infra/monitoring
+   ```
+
+3. Configure the Function App application settings via the Azure CLI, ARM/Bicep, or the portal as part of the workflow if
+desired (e.g. use `azure/appservice-settings@v2`).
+
+With the Function App deployed, the timer trigger will run every five minutes but only dispatch jobs when market hours are open
+and new heuristics cross the configured thresholds.

--- a/infra/monitoring/host.json
+++ b/infra/monitoring/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[3.*, 4.0.0)"
+  }
+}

--- a/infra/monitoring/local.settings.json.sample
+++ b/infra/monitoring/local.settings.json.sample
@@ -1,0 +1,21 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "MARKET_MONITOR_WATCHLIST": "AAPL,MSFT,NVDA",
+    "MARKET_MONITOR_QUEUE_NAME": "analysis-requests",
+    "MARKET_MONITOR_PERCENT_CHANGE_THRESHOLD": "0.02",
+    "MARKET_MONITOR_VOLUME_SPIKE_MULTIPLIER": "1.5",
+    "MARKET_MONITOR_VOLUME_LOOKBACK": "10",
+    "MARKET_MONITOR_ANALYSIS_WINDOW_MINUTES": "120",
+    "MARKET_MONITOR_COOLDOWN_SECONDS": "1800",
+    "MARKET_MONITOR_LOOKBACK_DAYS": "30",
+    "FINANCIAL_DATASETS_API_KEY": "<financialdatasets-key>",
+    "MARKET_MONITOR_QUEUE_CONNECTION_STRING": "<storage-connection-string>",
+    "COSMOS_ENDPOINT": "https://<account>.documents.azure.com:443/",
+    "COSMOS_KEY": "<cosmos-key>",
+    "COSMOS_DATABASE": "monitoring",
+    "COSMOS_CONTAINER": "ticker-cooldowns"
+  }
+}

--- a/infra/monitoring/market_monitor/__init__.py
+++ b/infra/monitoring/market_monitor/__init__.py
@@ -1,0 +1,315 @@
+import datetime as dt
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Iterable, Sequence
+from zoneinfo import ZoneInfo
+
+import azure.functions as func
+from azure.cosmos import CosmosClient, PartitionKey, exceptions as cosmos_exceptions
+from azure.storage.queue import QueueClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from src.data.models import Price  # noqa: E402
+from src.tools.api import get_prices  # noqa: E402
+
+
+EASTERN = ZoneInfo("America/New_York")
+
+
+@dataclass
+class SignalSummary:
+    ticker: str
+    percent_change: float
+    volume_ratio: float | None
+    latest: Price
+    previous: Price
+    average_volume: float | None
+    reasons: list[str]
+
+    @property
+    def triggered(self) -> bool:
+        return bool(self.reasons)
+
+
+class CosmosCooldownStore:
+    """Persist ticker trigger timestamps in Cosmos DB."""
+
+    def __init__(self, endpoint: str, key: str, database: str, container: str) -> None:
+        self._client = CosmosClient(url=endpoint, credential=key)
+        self._database = self._client.create_database_if_not_exists(id=database)
+        self._container = self._database.create_container_if_not_exists(
+            id=container,
+            partition_key=PartitionKey(path="/ticker"),
+            offer_throughput=400,
+        )
+
+    def get_last_trigger(self, ticker: str) -> dt.datetime | None:
+        try:
+            item = self._container.read_item(item=ticker, partition_key=ticker)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
+            return None
+        except cosmos_exceptions.CosmosHttpResponseError as exc:
+            logging.error("Cosmos read failed for %s: %s", ticker, exc)
+            return None
+
+        timestamp = item.get("last_triggered_utc")
+        if not timestamp:
+            return None
+        try:
+            parsed = dt.datetime.fromisoformat(timestamp)
+        except ValueError:
+            logging.warning("Invalid timestamp stored for %s: %s", ticker, timestamp)
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc)
+
+    def upsert_trigger(self, ticker: str, triggered_at: dt.datetime, reasons: list[str]) -> None:
+        payload = {
+            "id": ticker,
+            "ticker": ticker,
+            "last_triggered_utc": triggered_at.isoformat(),
+            "last_reasons": reasons,
+        }
+        try:
+            self._container.upsert_item(payload)
+        except cosmos_exceptions.CosmosHttpResponseError as exc:
+            logging.error("Failed to persist trigger for %s: %s", ticker, exc)
+
+
+def _parse_watchlist(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [token.strip().upper() for token in raw.split(",") if token.strip()]
+
+
+def _parse_price_time(value: str) -> dt.datetime:
+    sanitized = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(sanitized)
+    except ValueError:
+        for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+            try:
+                parsed = dt.datetime.strptime(value, fmt)
+                break
+            except ValueError:
+                continue
+        else:
+            logging.warning("Unable to parse price timestamp: %s", value)
+            parsed = dt.datetime.utcnow()
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _isoformat(timestamp: dt.datetime) -> str:
+    return timestamp.replace(microsecond=0).isoformat()
+
+
+def _load_queue_client() -> QueueClient:
+    connection = (
+        os.getenv("MARKET_MONITOR_QUEUE_CONNECTION_STRING")
+        or os.getenv("AZURE_STORAGE_QUEUE_CONNECTION_STRING")
+        or os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+        or os.getenv("AzureWebJobsStorage")
+    )
+    queue_name = (
+        os.getenv("MARKET_MONITOR_QUEUE_NAME")
+        or os.getenv("ALERT_QUEUE_NAME")
+        or os.getenv("AZURE_STORAGE_QUEUE_NAME")
+    )
+    if not connection or not queue_name:
+        raise RuntimeError("Queue storage configuration is missing")
+    client = QueueClient.from_connection_string(connection, queue_name)
+    try:
+        client.create_queue()
+    except Exception:  # Queue may already exist
+        pass
+    return client
+
+
+def _ensure_cosmos_store() -> CosmosCooldownStore:
+    endpoint = os.getenv("COSMOS_ENDPOINT")
+    key = os.getenv("COSMOS_KEY")
+    database = os.getenv("COSMOS_DATABASE")
+    container = os.getenv("COSMOS_CONTAINER")
+    if not all([endpoint, key, database, container]):
+        raise RuntimeError("Cosmos DB configuration is missing required settings")
+    return CosmosCooldownStore(endpoint, key, database, container)
+
+
+def _is_market_hours(now_utc: dt.datetime) -> bool:
+    eastern_now = now_utc.astimezone(EASTERN)
+    if eastern_now.weekday() >= 5:  # Saturday/Sunday
+        return False
+    market_open = eastern_now.replace(hour=9, minute=30, second=0, microsecond=0)
+    market_close = eastern_now.replace(hour=16, minute=0, second=0, microsecond=0)
+    return market_open <= eastern_now <= market_close
+
+
+def _history_window_days(volume_window: int) -> int:
+    default_days = int(os.getenv("MARKET_MONITOR_LOOKBACK_DAYS", "30"))
+    return max(default_days, volume_window + 2)
+
+
+def _fetch_price_history(ticker: str, start_date: str, end_date: str) -> list[Price]:
+    prices = get_prices(ticker=ticker, start_date=start_date, end_date=end_date)
+    prices = sorted(prices, key=lambda price: _parse_price_time(price.time))
+    return prices
+
+
+def _evaluate_signals(
+    ticker: str,
+    prices: Sequence[Price],
+    percent_threshold: float,
+    volume_multiplier: float,
+    volume_window: int,
+) -> SignalSummary | None:
+    if len(prices) < 2:
+        logging.info("Not enough price history for %s to compute signals", ticker)
+        return None
+
+    sorted_prices = list(prices)
+    latest = sorted_prices[-1]
+    previous = sorted_prices[-2]
+    if previous.close == 0:
+        logging.warning("Previous close is zero for %s; skipping", ticker)
+        return None
+
+    percent_change = (latest.close - previous.close) / previous.close
+
+    historical_window = sorted_prices[max(0, len(sorted_prices) - volume_window - 1) : -1]
+    average_volume = None
+    volume_ratio = None
+    if historical_window:
+        average_volume = mean(price.volume for price in historical_window)
+        if average_volume > 0:
+            volume_ratio = latest.volume / average_volume
+
+    reasons: list[str] = []
+    if percent_change >= percent_threshold:
+        reasons.append("price_breakout")
+    if volume_ratio is not None and volume_ratio >= volume_multiplier:
+        reasons.append("volume_spike")
+
+    summary = SignalSummary(
+        ticker=ticker,
+        percent_change=percent_change,
+        volume_ratio=volume_ratio,
+        latest=latest,
+        previous=previous,
+        average_volume=average_volume,
+        reasons=reasons,
+    )
+    return summary
+
+
+def _compose_queue_payload(
+    ticker: str,
+    triggered_at: dt.datetime,
+    analysis_window_minutes: int,
+    summary: SignalSummary,
+    watchlist: Iterable[str],
+) -> dict:
+    window_end = triggered_at
+    window_start = triggered_at - dt.timedelta(minutes=analysis_window_minutes)
+    correlation_hints = {
+        "related_watchlist": [symbol for symbol in watchlist if symbol != ticker],
+        "basis": summary.reasons,
+    }
+    payload = {
+        "tickers": [ticker],
+        "analysis_window": {
+            "start": _isoformat(window_start),
+            "end": _isoformat(window_end),
+        },
+        "correlation_hints": correlation_hints,
+        "signals": summary.reasons,
+        "market_snapshot": {
+            "percent_change": round(summary.percent_change, 6),
+            "volume_ratio": round(summary.volume_ratio, 6) if summary.volume_ratio is not None else None,
+            "latest_close": summary.latest.close,
+            "previous_close": summary.previous.close,
+            "latest_volume": summary.latest.volume,
+            "average_volume": summary.average_volume,
+        },
+        "triggered_at": _isoformat(triggered_at),
+    }
+    return payload
+
+
+def main(market_timer: func.TimerRequest) -> None:
+    logging.info("Market monitor timer triggered at %s", market_timer.schedule_status.last if market_timer and market_timer.schedule_status else "unknown")
+
+    now_utc = dt.datetime.now(dt.timezone.utc)
+    if not _is_market_hours(now_utc):
+        logging.info("Outside market hours - skipping execution")
+        return
+
+    watchlist_env = (
+        os.getenv("MARKET_MONITOR_WATCHLIST")
+        or os.getenv("WATCHLIST_TICKERS")
+        or os.getenv("DEFAULT_WATCHLIST")
+    )
+    watchlist = _parse_watchlist(watchlist_env)
+    if not watchlist:
+        watchlist = ["AAPL", "MSFT", "NVDA"]
+        logging.warning("No watchlist configured; falling back to default %s", watchlist)
+
+    percent_threshold = float(os.getenv("MARKET_MONITOR_PERCENT_CHANGE_THRESHOLD", "0.02"))
+    volume_multiplier = float(os.getenv("MARKET_MONITOR_VOLUME_SPIKE_MULTIPLIER", "1.5"))
+    volume_window = int(os.getenv("MARKET_MONITOR_VOLUME_LOOKBACK", "10"))
+    analysis_window_minutes = int(os.getenv("MARKET_MONITOR_ANALYSIS_WINDOW_MINUTES", "120"))
+    cooldown_seconds = int(os.getenv("MARKET_MONITOR_COOLDOWN_SECONDS", str(30 * 60)))
+
+    try:
+        queue_client = _load_queue_client()
+    except RuntimeError as exc:
+        logging.error("Queue client initialization failed: %s", exc)
+        return
+
+    try:
+        cooldown_store = _ensure_cosmos_store()
+    except RuntimeError as exc:
+        logging.error("Cosmos configuration error: %s", exc)
+        return
+
+    cooldown_window = dt.timedelta(seconds=cooldown_seconds)
+    history_days = _history_window_days(volume_window)
+    today_eastern = now_utc.astimezone(EASTERN).date()
+    start_date = (today_eastern - dt.timedelta(days=history_days)).isoformat()
+    end_date = today_eastern.isoformat()
+
+    for ticker in watchlist:
+        try:
+            prices = _fetch_price_history(ticker, start_date, end_date)
+        except Exception as exc:  # noqa: BLE001 - log and continue on data failure
+            logging.exception("Failed to fetch prices for %s: %s", ticker, exc)
+            continue
+
+        summary = _evaluate_signals(ticker, prices, percent_threshold, volume_multiplier, volume_window)
+        if not summary or not summary.triggered:
+            continue
+
+        last_trigger = cooldown_store.get_last_trigger(ticker)
+        if last_trigger and now_utc - last_trigger < cooldown_window:
+            logging.info("Ticker %s skipped due to cooldown (last trigger at %s)", ticker, last_trigger)
+            continue
+
+        payload = _compose_queue_payload(ticker, now_utc, analysis_window_minutes, summary, watchlist)
+        try:
+            queue_client.send_message(json.dumps(payload))
+            logging.info("Enqueued analysis request for %s with reasons %s", ticker, summary.reasons)
+            cooldown_store.upsert_trigger(ticker, now_utc, summary.reasons)
+        except Exception as exc:  # noqa: BLE001 - surface queue issues
+            logging.exception("Failed to enqueue analysis for %s: %s", ticker, exc)
+

--- a/infra/monitoring/market_monitor/function.json
+++ b/infra/monitoring/market_monitor/function.json
@@ -1,0 +1,11 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "market_timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}

--- a/infra/monitoring/requirements.txt
+++ b/infra/monitoring/requirements.txt
@@ -1,0 +1,6 @@
+azure-functions
+azure-storage-queue>=12.7.0
+azure-cosmos>=4.5.0
+requests>=2.31.0
+pandas>=2.1.0
+pydantic>=2.4.0


### PR DESCRIPTION
## Summary
- scaffold a Python Azure Functions app in `infra/monitoring` with a timer trigger that only proceeds during market hours
- add logic that reuses the Financial Datasets client to compute price/volume signals, enforce Cosmos-based cooldowns, and enqueue jobs with the expected payload schema
- document required configuration, local development tips, and deployment guidance for the monitoring function

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd6bec29e083219990cf00bbaf2ca6